### PR TITLE
[mingxoxo] programmers_더맵게_Python

### DIFF
--- a/programmers/힙.더맵게/mingxoxo.py
+++ b/programmers/힙.더맵게/mingxoxo.py
@@ -1,0 +1,14 @@
+from heapq import heapify, heappush, heappop
+
+def solution(scoville, K):
+    answer = 0
+    heapify(scoville) # 최소힙으로 재배열
+    
+    while 1 < len(scoville) and scoville[0] < K:
+        heappush(scoville, heappop(scoville) + heappop(scoville) * 2)
+        answer += 1
+
+    # 모든 음식의 스코빌 지수를 K 이상으로 만들 수 없는 경우 -1
+    if scoville[0] < K: 
+        return -1
+    return answer


### PR DESCRIPTION
## 🔗 문제 링크

https://school.programmers.co.kr/learn/courses/30/lessons/42626
- 모든 음식의 스코빌 지수를 K 이상으로 만들기 위해 섞어야 하는 최소 횟수를 return
  - K 이상으로 만들기 위해 스코빌 지수가 가장 낮은 두 개의 음식을 아래 식으로 변경
  - `섞은 음식의 스코빌 지수 = 가장 맵지 않은 음식의 스코빌 지수 + (두 번째로 맵지 않은 음식의 스코빌 지수 * 2)`

## 💡 풀이 아이디어

[heapq](https://docs.python.org/ko/3.13/library/heapq.html) 모듈을 사용하여 최소 힙을 사용하였습니다. heapq의 기본 동작은 value 값을 기준으로 최소 힙으로 배열합니다.

`scoville` 리스트를 heapify 함수를 통해 최소 힙으로 재배열 한 후, 리스트에 음식이 2개 이상 있을 경우 모든 음식의 스코빌 지수가 K 이상이 될 때까지 만들어 추가해줍니다.

만약 남은 음식이 K 미만의 스코빌 지수를 가질 경우 -1을 반환합니다.
사실 남은 음식이 K 미만일 경우 `scoville` 리스트의 개수가 1개인 경우만 있어 len을 사용해도 되었을 것 같은데, 리스트 원소를 직접 접근해서 사용해주었습니다.

## 📝 새로 학습한 내용


## 📚 참고 자료

