### PR TITLE
[mingxoxo] programmers_디스크 컨트롤러_Python

### DIFF
--- a/programmers/힙.디스크 컨트롤러/mingxoxo.py
+++ b/programmers/힙.디스크 컨트롤러/mingxoxo.py
@@ -1,0 +1,33 @@
+from heapq import heappush, heappop
+
+def solution(jobs):
+    req_heap = []
+    total = 0
+    
+    # 요청 시간 기준 힙 초기화
+    for i, times in enumerate(jobs):
+        heappush(req_heap, (*times, i))
+    
+    start = 0
+    task_heap = []
+    while req_heap or task_heap:
+        
+        # 작업 힙이 비어 있다면 요청 힙에서 하나 가져오기
+        if not task_heap:
+            req, dur, idx = heappop(req_heap)
+            heappush(task_heap, (dur, req, idx))
+        
+        # 현재 작업 처리
+        dur, req, idx = heappop(task_heap)
+        start = max(start, req)
+        end = start + dur
+
+        total += end - req
+        start = end
+        
+        # 시작 가능 작업을 작업 힙에 추가
+        while req_heap and req_heap[0][0] <= start:
+            req, dur, idx = heappop(req_heap)
+            heappush(task_heap, (dur, req, idx))
+    
+    return int(total / len(jobs))


### PR DESCRIPTION
## 🔗 문제 링크

https://school.programmers.co.kr/learn/courses/30/lessons/42627
- 우선순위 디스크 컨트롤러가 이 작업을 처리했을 때 모든 요청 작업의 반환 시간의 평균의 정수 부분을 반환

## 💡 풀이 아이디어

처음에는 하드 디스크에서 수행할 하나의 작업을 선택할 때 우선순위를 여러개 고려해야 한다는 부분에 꽂혀서 하나의 힙에 여러 가지 우선 순위를 고려할 수 있도록 처리하는 방법에 대해 고민했습니다.
우선 순위는 작업의 소요시간이 짧은 것, 작업의 요청 시각이 빠른 것, 작업의 번호가 작은 것 순으로 높습니다.

하지만 작업 요청이 들어오는 시점에 따라 시작하는 시간에 들어오지 않은 요청이 우선순위에 따라 선택되는 경우가 발생할 수 있습니다.
예시에서 0번 작업이 만약 1ms 에 끝난다고 가정하면 2번 작업은 현재 요청되지 않았기 때문에 1번 작업만을 선택할 수 있습니다.

따라서 작업이 끝날 때마다 추가할 수 있는 작업을 대기 큐 힙(`task_heap`)에 추가하도록 총 2개의 힙을 사용하였습니다.
- `req_heap`: 작업 요청 시각이 빠른 것이 우선 순위가 높도록 저장하는 최소 힙
- `task_heap`: 실제 처리할 수 있는 대기 큐 역할을 하는 최소 힙
  - 작업의 소요시간이 짧은 것(`dur`), 작업의 요청 시각이 빠른 것(`req`), 작업의 번호가 작은 것(`num`) 순으로 우선순위가 높도록 설정하기 위해 순서대로 튜플에 저장하여 추가해주었습니다. 이렇게 하면 맨 앞의 값부터 우선순위가 높습니다.

1. `req_heap` 에 요청 시간 기준으로 힙 초기화
2. 작업이 존재하는 동안 반복 실행
    2-1. 작업 힙이 비어있다면 요청 힙에서 가져오기
          - 끝난 시간 포함하여 이전에 들어온 요청이 없는 경우에 조건을 만족
  
    2-2. `task_heap` 에서 우선 순위가 가장 높은 작업을 가져와 작업 처리
        - 실제로 작업이 시작하는 시간 계산 (`max(start, req)`)
        - 끝난 시간 계산 후 반환 시간을 total에 더해줌
        - 시작 시간을 현재 작업의 끝난 시간으로 갱신
  
   2-3.
        - 시작 가능 작업을 `req_heap` 에서 가져와  `task_heap`에 추가


## 📝 새로 학습한 내용

항상 heapq 모듈을 사용하여 우선순위 큐(최소 힙, 최대 힙)을 구현했는데 검색해보니 priorityQueue라는 클래스도 존재했습니다. 관련된 내용을 정리한 블로그를 읽어보니
> 코딩 테스트의 경우에는, priorityQueue보다 heapq가 속도가 더 빠르기 때문에, heapq를 사용하도록 하자.

라는 내용이 있어서 heapq만 사용했었나..? 싶었는데 새로운 클래스를 알아서 신기했습니다 🤔


그리고 다른 사람의 풀이 중 작업 요청 시각이 빠른 작업을 처리하는 부분에서 queue를 사용하는 풀이가 인상깊었습니다! 제 풀이처럼 우선순위 큐를 사용하는 대신 정렬을 시킨 후 큐에서 선입 선출하는 구조로 처리하였습니다.

`tasks = deque(sorted([(x[1], x[0]) for x in jobs], key=lambda x: (x[1], x[0])))`

## 📚 참고 자료

[[파이썬] priorityQueue, heapq의 차이점은 뭘까?](https://velog.io/@ledcost/%ED%8C%8C%EC%9D%B4%EC%8D%AC-priorityQueue-heapq%EC%9D%98-%EC%B0%A8%EC%9D%B4%EC%A0%90%EC%9D%80-%EB%AD%98%EA%B9%8C)

