### PR TITLE
[sangkyu39] programmers_디스크컨트롤러_Python

### DIFF
--- a/programmers/힙.디스크컨트롤러/sangkyu39.py
+++ b/programmers/힙.디스크컨트롤러/sangkyu39.py
@@ -1,0 +1,18 @@
+def solution(jobs):     
+    jobs.sort(key=lambda x:-x[0]) #작업을 요청 시간 역순으로 정렬
+    time = jobs[-1][0] # 요청 시간이 가장 빠른 것 시간 선택
+    buffer = []
+    turnTime = 0
+    jobCnt = len(jobs)
+    while buffer or jobs:
+        while jobs and jobs[-1][0] <= time: # 뒤에서 부터 요청시간이 지난 것까지만 힙에 넣기 
+            start, duration = jobs.pop() 
+            hq.heappush(buffer, (duration, start)) # 힙 정렬을 위해 소요시간과 요청 시간 반대로 넣기 
+        if not buffer: # 대기하는 작업이 없는데 시간이 안 흐를 때 
+            time = jobs[-1][0]
+            continue
+        job = hq.heappop(buffer) # 가장 소요시간이 적은 것 POP
+        time += job[0] # 소요시간 더하기
+        turnTime += time - job[1]
+
+    return turnTime // jobCnt


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 작성해주세요!)
✔️ 파일 경로 확인!
  - 경로 형식: `문제사이트/문제이름/본인깃허브아이디.확장자`
    - 문제이름: `번호.문제명` 또는 `문제명`(띄어쓰기는 모두 _로 치환)
    - 예시: `BOJ/17413.단어_뒤집기_2/mingxoxo.py` `Programmers/문제_제목/mingxoxo.cpp`
✔️ Assignees 본인으로 추가
✔️ 문제 사이트, 풀이 언어 Label 추가
✔️ 아래 각 항목에 내용을 작성 

-->

## 🔗 문제 링크

<!-- 문제 링크 -->
<!-- 필요하다면 문제에 대한 간단한 설명도 해주세요 -->작업들의 요청시간과 소요 시간이 주어진다. 작업은 한번에 한 작업만 가능하며 한 작업이 끝나면 요청된 작업 중 가장 소요시간이 짧은 작업부터 시각된다. 이때 요청시간과 작업이 완료된 시간차를 반환 시간으로 하였을 때 각 반환시간의 평균을 return 하시오 
## 💡 풀이 아이디어
먼저 작업들을 요청시간 순서대로 구현한 후 일정 시간이 되었을 때 가능한 작업 중 소요시간이 가장 적은 작업을 작업하는 방식을 구상하였다. 이때 가장 소요시간이 적은 작업은 시간이 지날 때 마다 새로운 작업이 들어오기때문에 힙으로 구현되어야 한다. 
```
import heapq as hq

def solution(jobs):     
    jobs.sort(key=lambda x:-x[0]) #작업을 요청 시간 역순으로 정렬
    time = jobs[-1][0] # 요청 시간이 가장 빠른 것 시간 선택
    buffer = []
    turnTime = 0
    jobCnt = len(jobs)
    while buffer or jobs:
        while jobs and jobs[-1][0] <= time: # 뒤에서 부터 요청시간이 지난 것까지만 힙에 넣기 
            start, duration = jobs.pop() 
            hq.heappush(buffer, (duration, start)) # 힙 정렬을 위해 소요시간과 요청 시간 반대로 넣기 
        if not buffer: # 대기하는 작업이 없는데 시간이 안 흐를 때 
            time = jobs[-1][0]
            continue
        job = hq.heappop(buffer) # 가장 소요시간이 적은 것 POP
        time += job[0] # 소요시간 더하기
        turnTime += time - job[1]

    return turnTime // jobCnt
```

처음에 앞의 작업이 완료된 시간보다 다음 작업의 요청 시간이 훨씬 뒤인 경우를 생각하지 못해 계속 틀렸었다. 
<!-- 문제 접근 방식, 구현 과정 등에 대해서 정리해주세요 -->

## 📝 새로 학습한 내용
힙에 넣은 후에는 소요시간 순으로 힙을 정렬하기 위해 
```
 hq.heappush(buffer, (duration, start))
```
다음 처럼 힙에 형식을 지정해서 넣어줄 수 있고, 힙은 가장 첫번째 인자를 기준으로 정렬한다는 것을 알게되었다. 

<!-- 문제를 풀면서 새로 알게된 알고리즘이라던가, 함수 등이 있다면 정리해주세요 -->
<!-- 동일한 문제의 다른 사람의 풀이를 확인해보는 것을 추천드립니다 -->
<!-- 작성할 내용이 없는 경우 내용을 비워주세요 -->

## 📚 참고 자료

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
<!-- 작성할 내용이 없는 경우 내용을 비워주세요 -->
