### PR TITLE
[seungbinpark] programmers_더 맵게_Python

### DIFF
--- a/Programmers/더 맵게/seungbin.py
+++ b/Programmers/더 맵게/seungbin.py
@@ -1,0 +1,16 @@
+import heapq
+def solution(scoville, K):
+    cnt=0
+    heapq.heapify(scoville) # 최소 힙으로 변환
+    
+    while(scoville[0]<K):
+        if len(scoville)==1: # K를 넘기지 못 할 경우
+            return -1
+        
+        sco_1 = heapq.heappop(scoville) # 가장 맵지 않은 음식
+        sco_2 = heapq.heappop(scoville) # 다음으로 맵지 않은 음식
+        
+        heapq.heappush(scoville, sco_1 + sco_2 * 2) # 새로운 음식 만들어서 추가
+        cnt+=1 # 섞은 횟수 업데이트
+        
+    return cnt


### PR DESCRIPTION
## 🔗 문제 링크

https://school.programmers.co.kr/learn/courses/30/lessons/42626

- 모든 음식의 스코빌 지수가 K 이상이 될 때까지 반복하여 섞는다.
- 모든 음식의 스코빌 지수를 K 이상으로 만들기 위해 섞어야 하는 최소 횟수를 return
- 모든 음식의 스코빌 지수를 K 이상으로 만들 수 없는 경우에는 -1을 return

<섞는 방법>
섞은 음식의 스코빌 지수 = 가장 맵지 않은 음식의 스코빌 지수 + (두 번째로 맵지 않은 음식의 스코빌 지수 * 2)


## 💡 풀이 아이디어

- heapq 모듈을 활용하여 스코빌 지수를 힙의 형태로 변환
- 가장 작은 스코빌 지수가 K와 같거나 커지기 전까지 while문
- heappop 함수를 사용해 가장 작은 원소를 힙에서 제거함과 동시에 그를 결괏값으로 리턴
- 스코빌 지수가 하나 남았지만 K를 넘지 못하였을 때 -1 return
- sco_1 : 가장 맵지 않은 음식의 스코빌 지수
- sco_2 : 두 번째로 맵지 않은 음식의 스코빌 지수
- 위 섞는 방법으로 스코빌 지수에 heappush로 다시 넣어주기(cnt 1증가)
- cnt : 섞은 횟수

```ruby
import heapq
def solution(scoville, K):
    cnt=0
    heapq.heapify(scoville) # 최소 힙으로 변환
    
    while(scoville[0]<K):
        if len(scoville)==1: # K를 넘기지 못 할 경우
            return -1
        
        sco_1 = heapq.heappop(scoville) # 가장 맵지 않은 음식
        sco_2 = heapq.heappop(scoville) # 다음으로 맵지 않은 음식
        
        heapq.heappush(scoville, sco_1 + sco_2 * 2) # 새로운 음식 만들어서 추가
        cnt+=1 # 섞은 횟수 업데이트
        
    return cnt
```


## 📝 새로 학습한 내용

heapq 모듈
heapq.heappop(heap): 가장 작은 원소를 힙에서 제거 후 리턴, 비어있는 경우 IndexError
heapq.heapify(x): 리스트 x를 힙 자료형으로 변환
heapq.heappush(heap, item) : item을 heap에 추가


## 📚 참고 자료

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
<!-- 작성할 내용이 없는 경우 내용을 비워주세요 -->
